### PR TITLE
Fix meadowlark GIF pixel icon

### DIFF
--- a/pkg/yoto/icon_uploader.go
+++ b/pkg/yoto/icon_uploader.go
@@ -74,7 +74,7 @@ func (iu *IconUploader) UploadIcon(filePath string, filename string) (string, er
 	}
 
 	// Build URL with query parameters
-	url := fmt.Sprintf("%s/media/displayIcons/user/me/upload?autoConvert=true&filename=%s",
+	url := fmt.Sprintf("%s/media/displayIcons/user/me/upload?autoConvert=false&filename=%s",
 		iu.client.baseURL, filename)
 
 	// Create request with raw image data (as shown in Yoto docs)


### PR DESCRIPTION
This pull request makes a minor change to the icon upload logic, specifically altering the behavior of the image conversion during upload.

- Changed the `autoConvert` query parameter from `true` to `false` in the upload URL within the `UploadIcon` method of `icon_uploader.go`, so uploaded icons will no longer be automatically converted by the server. (Hoping this will allow for the pixel icon movement to be visible on the Yoto player. 🤞🏻 )